### PR TITLE
Add setup scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,17 @@ uvicorn main:app --reload --host 0.0.0.0 --port 4000
 npm install
 ```
 
+Alternatively, run the provided setup script which also installs all
+development dependencies:
+```bash
+./scripts/setup.sh
+```
+
+To verify that all required packages are installed, you can run:
+```bash
+./scripts/check-deps.sh
+```
+
 2. Start the development server:
 ```bash
 npm run dev

--- a/scripts/check-deps.sh
+++ b/scripts/check-deps.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Check for missing npm packages
+
+npm ls >/dev/null 2>&1
+if [ $? -ne 0 ]; then
+  echo "Some npm packages are missing. Run './scripts/setup.sh' to install them."
+  exit 1
+else
+  echo "All npm packages are installed."
+fi

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Setup script for Economic Toolkit
+# Installs Node.js dependencies including dev packages
+set -e
+
+echo "Installing Node.js dependencies..."
+npm install
+
+echo "Node.js dependencies installed."


### PR DESCRIPTION
## Summary
- add scripts for installing and checking npm deps
- document the setup and dependency checks in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686be17841348322b0cec6261e26d7d5