### PR TITLE
Use aiohttp for async news fetching

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,7 +1,7 @@
 fastapi==0.110.0
 uvicorn==0.27.1
 python-dotenv==1.0.1
-requests==2.31.0
+aiohttp==3.9.1
 pymongo==4.6.2
 python-crontab==3.0.0
 motor>=3.0.0


### PR DESCRIPTION
## Summary
- switch `requests` to `aiohttp` in `news_fetcher`
- fetch headlines using an async `ClientSession`
- offload summarization and article parsing to threads
- update requirements

## Testing
- `python -m py_compile backend/*.py`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686c06b9c30883229329dc76b728117c