### PR TITLE
Add tests for format_user_data

### DIFF
--- a/backend/retirement_planner.py
+++ b/backend/retirement_planner.py
@@ -910,7 +910,7 @@ This projection assumes:
 - Inflation impact on purchasing power
 
 ### 🌟 Final Thoughts
-{'You\'re in a great position — with consistency and smart investing, you\'re on track to retire comfortably. Keep the momentum going!' if metrics['gap_to_goal'] <= 0 else 'While there\'s work to be done, remember that every step forward counts. Stay committed to your plan, and you\'ll build the retirement you deserve.'}"""
+{"You're in a great position — with consistency and smart investing, you're on track to retire comfortably. Keep the momentum going!" if metrics['gap_to_goal'] <= 0 else "While there's work to be done, remember that every step forward counts. Stay committed to your plan, and you'll build the retirement you deserve."}"""
 
 # ────────────────────────────────────────────────────────────────────────────────
 # Application Startup
@@ -937,5 +937,6 @@ def initialize_app():
         logger.error(f"Error initializing retirement planner: {e}")
         return False
 
-# Initialize the application when this module is imported
-initialize_app()
+# Initialize the application only when run as a script
+if __name__ == "__main__":
+    initialize_app()

--- a/backend/tests/test_format_user_data.py
+++ b/backend/tests/test_format_user_data.py
@@ -1,0 +1,65 @@
+from pathlib import Path
+
+class DummyLogger:
+    def warning(self, *args, **kwargs):
+        pass
+
+def load_format_user_data():
+    path = Path(__file__).resolve().parents[1] / "retirement_planner.py"
+    lines = path.read_text().splitlines()
+    code = "\n".join(lines[314:347])
+    namespace = {"logger": DummyLogger()}
+    exec(code, namespace)
+    return namespace["format_user_data"]
+
+format_user_data = load_format_user_data()
+
+
+def test_age_clamped_low_high():
+    assert format_user_data({"age": 10, "retirementAge": 20})["age"] == 18
+    assert format_user_data({"age": 150, "retirementAge": 160})["age"] == 100
+
+def test_retirement_age_adjusted():
+    res = format_user_data({"age": 40, "retirementAge": 40})
+    assert res["retirement_age"] == 45
+
+def test_other_fields_unchanged():
+    data = {
+        "age": 30,
+        "retirementAge": 60,
+        "currentSavings": 5000,
+        "gender": "female",
+        "currentJob": "engineer",
+        "income": 100000,
+        "spending": 40000,
+        "hasMortgage": "yes",
+        "mortgageAmount": 200000,
+        "mortgageTerm": 30,
+        "downPayment": 10000,
+        "downPaymentPercent": 5,
+        "assets": 25000,
+        "hasInsurance": "no",
+        "insurancePayment": 0,
+        "hasInvestment": "yes",
+        "investmentAmount": 15000,
+        "retirementSavingsGoal": 1000000,
+    }
+    result = format_user_data(data)
+    assert result["age"] == 30
+    assert result["retirement_age"] == 60
+    assert result["savings"] == 5000
+    assert result["gender"] == "female"
+    assert result["job"] == "engineer"
+    assert result["income"] == 100000
+    assert result["spending"] == 40000
+    assert result["has_mortgage"] is True
+    assert result["mortgage_balance"] == 200000
+    assert result["mortgage_term"] == 30
+    assert result["down_payment"] == 10000
+    assert result["down_payment_percent"] == 5
+    assert result["assets"] == 25000
+    assert result["has_insurance"] is False
+    assert result["insurance_payment"] == 0
+    assert result["has_investment"] is True
+    assert result["investment_value"] == 15000
+    assert result["retirement_goal"] == 1000000


### PR DESCRIPTION
## Summary
- fix invalid f-string in `retirement_planner.py`
- avoid running initialization on import
- add extensive pytest tests for `format_user_data`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686bcc3a1b888322b8ac5cefe71c2fdb