### PR TITLE
Enforce NEWS_API_KEY env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,10 @@ The application will be available at `http://localhost:5173`.
 ### Backend (.env)
 ```
 MONGODB_URI=your_mongodb_connection_string
-NEWSAPI_KEY=your_newsapi_key
+NEWS_API_KEY=your_newsapi_key
 PORT=4000
 ```
+The `NEWS_API_KEY` variable is required and no default key is provided.
 
 ## API Endpoints
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,1 +1,3 @@
 MONGODB_URI=mongodb://localhost:27017/news_digest
+NEWS_API_KEY=your_newsapi_key
+

--- a/backend/main.py
+++ b/backend/main.py
@@ -37,7 +37,9 @@ scheduler = AsyncIOScheduler()
 
 
 # Initialize NewsFetcher
-NEWS_API_KEY = os.getenv("NEWS_API_KEY", "d403798f40db4331bae14a26284e9d71")
+NEWS_API_KEY = os.getenv("NEWS_API_KEY")
+if not NEWS_API_KEY:
+    raise EnvironmentError("NEWS_API_KEY environment variable is required")
 news_fetcher = NewsFetcher(api_key=NEWS_API_KEY, db=db)
 
 def fetch_with_retry(ticker, retries=3):


### PR DESCRIPTION
## Summary
- require NEWS_API_KEY in backend
- document required NEWS_API_KEY variable
- update backend environment example

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686c0cee4a2c83228fe968c18701cb63