### PR TITLE
Add time import and fix tests

### DIFF
--- a/backend/retirement_planner.py
+++ b/backend/retirement_planner.py
@@ -6,6 +6,7 @@ import hashlib
 import faiss
 import numpy as np
 import ollama
+import time
 from sentence_transformers import SentenceTransformer, CrossEncoder
 from langchain_core.documents import Document
 from langchain_text_splitters import RecursiveCharacterTextSplitter

--- a/backend/test/test_format_user_data.py
+++ b/backend/test/test_format_user_data.py
@@ -7,7 +7,7 @@ class DummyLogger:
 def load_format_user_data():
     path = Path(__file__).resolve().parents[1] / "retirement_planner.py"
     lines = path.read_text().splitlines()
-    code = "\n".join(lines[314:347])
+    code = "\n".join(lines[346:379])
     namespace = {"logger": DummyLogger()}
     exec(code, namespace)
     return namespace["format_user_data"]


### PR DESCRIPTION
## Summary
- import time in `retirement_planner.py`
- update test slice to account for line offset

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c210805808322b99bdfa05781ca17