### PR TITLE
Initialize retirement planner on startup

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -18,7 +18,7 @@ import asyncio
 from typing import List
 from database import db
 from news_fetcher import NewsFetcher
-from retirement_planner import router as retirement_router
+from retirement_planner import router as retirement_router, initialize_app
 from functools import lru_cache
 import finnhub
 
@@ -55,6 +55,9 @@ def fetch_with_retry(ticker, retries=3):
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     logger.info("Starting lifespan")
+
+    # Initialize resources for retirement planner
+    initialize_app()
 
     scheduler.add_job(news_fetcher.fetch_and_save_business_us, 'interval', hours=1)
     scheduler.start()

--- a/backend/retirement_planner.py
+++ b/backend/retirement_planner.py
@@ -974,5 +974,3 @@ def initialize_app():
         logger.error(f"Error initializing retirement planner: {e}")
         return False
 
-# Initialize the application when this module is imported
-initialize_app()


### PR DESCRIPTION
## Summary
- remove automatic initialization when importing `retirement_planner`
- invoke `initialize_app()` during FastAPI lifespan in `main.py`
- adjust tests to import the module directly and stub heavy dependencies

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c227c01608322be8175968bccd6f9