### PR TITLE
Use API client in retirement planner

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
 VITE_HUGGINGFACE_TOKEN=your_huggingface_token_here
+VITE_API_BASE_URL=/api

--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ NEWSAPI_KEY=your_newsapi_key
 PORT=4000
 ```
 
+### Frontend (.env)
+```
+VITE_HUGGINGFACE_TOKEN=your_huggingface_token_here
+VITE_API_BASE_URL=/api
+```
+
 ## API Endpoints
 
 | Method | Endpoint | Description |

--- a/src/pages/RetirementPlanner.tsx
+++ b/src/pages/RetirementPlanner.tsx
@@ -1,7 +1,6 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
-import axios from 'axios';
 import { 
   DollarSign, 
   User, 
@@ -84,11 +83,11 @@ const RetirementPlanner = () => {
     try {
       console.log("📤 Sending data to backend:", formData);
 
-      const response = await axios.post("http://localhost:4000/api/retirement/plan", formData);
+      const planData = await retirementApi.generatePlan(formData as RetirementPlanInput);
 
-      console.log("✅ Received plan from backend:", response.data.retirement_plan);
+      console.log("✅ Received plan from backend:", planData);
       // Navigate and pass plan data to the result page
-      navigate("/retirement-plan", { state: { planData: response.data.retirement_plan } });
+      navigate("/retirement-plan", { state: { planData } });
     } catch (error) {
       console.error("❌ Error generating retirement plan:", error);
       setError("Failed to generate retirement plan. Please try again.");

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-const API_BASE_URL = '/api';
+export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api';
 
 export interface Article {
   _id: string;


### PR DESCRIPTION
## Summary
- remove direct axios call
- use `retirementApi.generatePlan` for retirement planner requests
- make API base URL configurable
- document new environment variable

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `pytest` *(fails: TypeError: 'NoneType' object is not subscriptable)*

------
https://chatgpt.com/codex/tasks/task_e_686c425f75348322bcff331e0f86516d